### PR TITLE
Fix content type

### DIFF
--- a/src/service.rs
+++ b/src/service.rs
@@ -129,7 +129,7 @@ impl Service {
         let soap_action = format!("\"{}#{}\"", &self.service_type, action);
 
         let request = Request::post(self.control_url(url))
-            .header("CONTENT-TYPE", "xml")
+            .header("CONTENT-TYPE", "text/xml")
             .header("SOAPAction", soap_action)
             .body(body.into())
             .expect("infallible");


### PR DESCRIPTION
When running actions content type `xml` is used instead of `text/xml`. This is incorrect and breaks UPnP specification, device must send `415` error code on such requests. This PR fixes it.