### PR TITLE
Save optional extra device elements in device spec

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rupnp"
-version = "2.0.0"
+version = "2.1.0"
 authors = ["Jakob Hellermann <jakob.hellermann@protonmail.com>"]
 readme = "README.md"
 repository = "https://github.com/jakobhellermann/rupnp"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rupnp"
-version = "2.1.0"
+version = "2.1.1"
 authors = ["Jakob Hellermann <jakob.hellermann@protonmail.com>"]
 readme = "README.md"
 repository = "https://github.com/jakobhellermann/rupnp"

--- a/examples/discover_extra_fields.rs
+++ b/examples/discover_extra_fields.rs
@@ -1,0 +1,27 @@
+use futures::prelude::*;
+use rupnp::ssdp::SearchTarget;
+use std::time::Duration;
+
+const EXTRA: &[&str; 1] = &["manufacturerURL"];
+
+#[tokio::main]
+async fn main() -> Result<(), rupnp::Error> {
+    let devices =
+        rupnp::discover_with_fields(&SearchTarget::RootDevice, Duration::from_secs(3), EXTRA)
+            .await?;
+    pin_utils::pin_mut!(devices);
+
+    while let Some(maybe_device) = devices.next().await {
+        match maybe_device {
+            Ok(device) => println!(
+                "{} has {} = {}",
+                device.friendly_name(),
+                EXTRA[0],
+                device.get_extra_element(EXTRA[0]).unwrap_or_default()
+            ),
+            _ => (),
+        };
+    }
+
+    Ok(())
+}

--- a/examples/discover_extra_fields.rs
+++ b/examples/discover_extra_fields.rs
@@ -7,7 +7,7 @@ const EXTRA: &[&str; 2] = &["manufacturer", "manufacturerURL"];
 #[tokio::main]
 async fn main() -> Result<(), rupnp::Error> {
     let devices =
-        rupnp::discover_with_fields(&SearchTarget::RootDevice, Duration::from_secs(3), EXTRA)
+        rupnp::discover_with_properties(&SearchTarget::RootDevice, Duration::from_secs(3), EXTRA)
             .await?;
     pin_utils::pin_mut!(devices);
 
@@ -16,8 +16,8 @@ async fn main() -> Result<(), rupnp::Error> {
             Ok(device) => println!(
                 "{} from {} @ {}",
                 device.friendly_name(),
-                device.get_extra_element(EXTRA[0]).unwrap_or_default(),
-                device.get_extra_element(EXTRA[1]).unwrap_or_default()
+                device.get_extra_property(EXTRA[0]).unwrap_or_default(),
+                device.get_extra_property(EXTRA[1]).unwrap_or_default()
             ),
             _ => (),
         };

--- a/examples/discover_extra_fields.rs
+++ b/examples/discover_extra_fields.rs
@@ -2,7 +2,7 @@ use futures::prelude::*;
 use rupnp::ssdp::SearchTarget;
 use std::time::Duration;
 
-const EXTRA: &[&str; 1] = &["manufacturerURL"];
+const EXTRA: &[&str; 2] = &["manufacturer", "manufacturerURL"];
 
 #[tokio::main]
 async fn main() -> Result<(), rupnp::Error> {
@@ -14,10 +14,10 @@ async fn main() -> Result<(), rupnp::Error> {
     while let Some(maybe_device) = devices.next().await {
         match maybe_device {
             Ok(device) => println!(
-                "{} has {} = {}",
+                "{} from {} @ {}",
                 device.friendly_name(),
-                EXTRA[0],
-                device.get_extra_element(EXTRA[0]).unwrap_or_default()
+                device.get_extra_element(EXTRA[0]).unwrap_or_default(),
+                device.get_extra_element(EXTRA[1]).unwrap_or_default()
             ),
             _ => (),
         };

--- a/src/device.rs
+++ b/src/device.rs
@@ -6,6 +6,7 @@ use crate::{
 use http::Uri;
 use roxmltree::{Document, Node};
 use ssdp_client::URN;
+use std::collections::HashMap;
 use std::hash::Hash;
 use std::hash::Hasher;
 
@@ -26,6 +27,12 @@ impl Device {
     /// The url should point to the `/device_description.xml` or similar of the device.
     /// If you dont know the concrete location, use [`discover`](fn.discover.html) instead.
     pub async fn from_url(url: Uri) -> Result<Self> {
+        Self::from_url_and_fields(url, &[]).await
+    }
+
+    /// Creates a UPnP device from the given url, defining extra device elements
+    /// to be accessed with `get_extra_element`.
+    pub async fn from_url_and_fields(url: Uri, extra_fields: &[&str]) -> Result<Self> {
         let body = hyper::Client::new()
             .get(url.clone())
             .await?
@@ -35,9 +42,9 @@ impl Device {
             .await?;
         let body = std::str::from_utf8(&body)?;
 
-        let document = Document::parse(&body)?;
+        let document = Document::parse(body)?;
         let device = utils::find_root(&document, "device", "Device Description")?;
-        let device_spec = DeviceSpec::from_xml(device)?;
+        let device_spec = DeviceSpec::from_xml(device, extra_fields)?;
 
         Ok(Self { url, device_spec })
     }
@@ -63,11 +70,11 @@ impl Eq for Device {}
 
 /// Information about a device.
 ///
-/// By default it only includes its *friendly name*, device type and a list of subdevices and
-/// services in order to keep the structs size small.
+/// By default it only includes its *friendly name*, device type, a list of subdevices and
+/// services, and a `HashMap` of extra fields/values in order to keep the structs size small.
 ///
 /// If you also want the `ManufacturerURL`, `Model{Description,Number,Url}`, `serial number`, `UDN` and
-/// `UPC`, enable the `full_device_spec` feature.
+/// `UPC` as struct fields, enable the `full_device_spec` feature.
 #[derive(Debug, Clone)]
 pub struct DeviceSpec {
     device_type: URN,
@@ -75,6 +82,8 @@ pub struct DeviceSpec {
 
     devices: Vec<DeviceSpec>,
     services: Vec<Service>,
+
+    extra_elements: HashMap<String, Option<String>>,
 
     #[cfg(feature = "full_device_spec")]
     manufacturer: String,
@@ -99,10 +108,14 @@ pub struct DeviceSpec {
 }
 
 impl DeviceSpec {
-    fn from_xml<'a, 'input: 'a>(node: Node<'a, 'input>) -> Result<Self> {
+    fn from_xml<'a, 'input: 'a>(
+        node: Node<'a, 'input>,
+        extra_fields: &[&str],
+    ) -> Result<Self> {
+        #[rustfmt::skip]
         #[allow(non_snake_case)]
-        let (device_type, friendly_name, services, devices) =
-            find_in_xml! { node => deviceType, friendlyName, ?serviceList, ?deviceList };
+        let (device_type, friendly_name, services, devices, extra_elements) = 
+            find_in_xml! { node => deviceType, friendlyName, ?serviceList, ?deviceList, #extra_fields };
 
         #[cfg(feature = "full_device_spec")]
         #[allow(non_snake_case)]
@@ -138,7 +151,7 @@ impl DeviceSpec {
             Some(d) => d
                 .children()
                 .filter(Node::is_element)
-                .map(DeviceSpec::from_xml)
+                .map(|node| DeviceSpec::from_xml(node, extra_fields))
                 .collect::<Result<_>>()?,
             None => Vec::new(),
         };
@@ -176,6 +189,7 @@ impl DeviceSpec {
             presentation_url,
             devices,
             services,
+            extra_elements,
         })
     }
 
@@ -184,6 +198,12 @@ impl DeviceSpec {
     }
     pub fn friendly_name(&self) -> &str {
         &self.friendly_name
+    }
+    pub fn get_extra_element(&self, elem: &str) -> Option<&str> {
+        self.extra_elements
+            .get(elem)
+            .and_then(|o| o.as_ref())
+            .map(String::as_str)
     }
 
     #[cfg(feature = "full_device_spec")]

--- a/src/discovery.rs
+++ b/src/discovery.rs
@@ -32,7 +32,7 @@ pub async fn discover(
     search_target: &SearchTarget,
     timeout: Duration,
 ) -> Result<impl Stream<Item = Result<Device>>> {
-    return discover_with_fields(search_target, timeout, &[]).await;
+    return discover_with_properties(search_target, timeout, &[]).await;
 }
 
 /// Discovers UPnP devices on the network and saves extra_fields in device descriptions
@@ -43,30 +43,30 @@ pub async fn discover(
 /// use std::time::Duration;
 /// use rupnp::ssdp::SearchTarget;
 ///
-/// # async fn discover_with_fields() -> Result<(), rupnp::Error> {
-/// let devices = rupnp::discover_with_fields(&SearchTarget::RootDevice, Duration::from_secs(3), &["manufacturer", "manufacturerURL"]).await?;
+/// # async fn discover_with_properties() -> Result<(), rupnp::Error> {
+/// let devices = rupnp::discover_with_properties(&SearchTarget::RootDevice, Duration::from_secs(3), &["manufacturer", "manufacturerURL"]).await?;
 /// pin_utils::pin_mut!(devices);
 ///
 /// while let Some(device) = devices.try_next().await? {
 ///     println!(
 ///         "{} - {} @ {}",
 ///         device.device_type(),
-///         device.get_extra_element("manufacturer").unwrap_or_default(),
-///         device.get_extra_element("manufacturerURL").unwrap_or_default()
+///         device.get_extra_property("manufacturer").unwrap_or_default(),
+///         device.get_extra_property("manufacturerURL").unwrap_or_default()
 ///     );
 /// }
 ///
 /// # Ok(())
 /// # }
 /// ```
-pub async fn discover_with_fields<'a>(
+pub async fn discover_with_properties<'a>(
     search_target: &SearchTarget,
     timeout: Duration,
-    extra_fields: &'a [&'a str],
+    extra_keys: &'a [&'a str],
 ) -> Result<impl Stream<Item = Result<Device>> + 'a> {
     Ok(ssdp_client::search(search_target, timeout, 3, None)
         .await?
         .map_err(Error::SSDPError)
         .map(|res| Ok(res?.location().parse()?))
-        .and_then(move |url| Device::from_url_and_fields(url, extra_fields)))
+        .and_then(move |url| Device::from_url_and_properties(url, extra_keys)))
 }

--- a/src/discovery.rs
+++ b/src/discovery.rs
@@ -32,20 +32,39 @@ pub async fn discover(
     search_target: &SearchTarget,
     timeout: Duration,
 ) -> Result<impl Stream<Item = Result<Device>>> {
-    Ok(ssdp_client::search(search_target, timeout, 3, None)
-        .await?
-        .map_err(Error::SSDPError)
-        .map(|res| Ok(res?.location().parse()?))
-        .and_then(Device::from_url))
+    return discover_with_fields(search_target, timeout, &[]).await;
 }
 
-/// Discovers UPnP devices and saves extra elements in device descriptions
+/// Discovers UPnP devices on the network and saves extra_fields in device descriptions
+///
+/// # Example usage:
+/// ```rust,no_run
+/// use futures::prelude::*;
+/// use std::time::Duration;
+/// use rupnp::ssdp::SearchTarget;
+///
+/// # async fn discover_with_fields() -> Result<(), rupnp::Error> {
+/// let devices = rupnp::discover_with_fields(&SearchTarget::RootDevice, Duration::from_secs(3), &["manufacturer", "manufacturerURL"]).await?;
+/// pin_utils::pin_mut!(devices);
+///
+/// while let Some(device) = devices.try_next().await? {
+///     println!(
+///         "{} - {} @ {}",
+///         device.device_type(),
+///         device.get_extra_element("manufacturer").unwrap_or_default(),
+///         device.get_extra_element("manufacturerURL").unwrap_or_default()
+///     );
+/// }
+///
+/// # Ok(())
+/// # }
+/// ```
 pub async fn discover_with_fields<'a>(
     search_target: &SearchTarget,
     timeout: Duration,
     extra_fields: &'a [&'a str],
 ) -> Result<impl Stream<Item = Result<Device>> + 'a> {
-    Ok(ssdp_client::search(search_target, timeout, 3)
+    Ok(ssdp_client::search(search_target, timeout, 3, None)
         .await?
         .map_err(Error::SSDPError)
         .map(|res| Ok(res?.location().parse()?))

--- a/src/discovery.rs
+++ b/src/discovery.rs
@@ -38,3 +38,16 @@ pub async fn discover(
         .map(|res| Ok(res?.location().parse()?))
         .and_then(Device::from_url))
 }
+
+/// Discovers UPnP devices and saves extra elements in device descriptions
+pub async fn discover_with_fields<'a>(
+    search_target: &SearchTarget,
+    timeout: Duration,
+    extra_fields: &'a [&'a str],
+) -> Result<impl Stream<Item = Result<Device>> + 'a> {
+    Ok(ssdp_client::search(search_target, timeout, 3)
+        .await?
+        .map_err(Error::SSDPError)
+        .map(|res| Ok(res?.location().parse()?))
+        .and_then(move |url| Device::from_url_and_fields(url, extra_fields)))
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -57,7 +57,7 @@ mod service;
 mod utils;
 
 pub use device::{Device, DeviceSpec};
-pub use discovery::{discover, discover_with_fields};
+pub use discovery::{discover, discover_with_properties};
 pub use error::Error;
 pub use service::Service;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -57,7 +57,7 @@ mod service;
 mod utils;
 
 pub use device::{Device, DeviceSpec};
-pub use discovery::discover;
+pub use discovery::{discover, discover_with_fields};
 pub use error::Error;
 pub use service::Service;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -54,7 +54,7 @@ mod error;
 /// Service Control Protocol Description.
 pub mod scpd;
 mod service;
-mod utils;
+pub mod utils;
 
 pub use device::{Device, DeviceSpec};
 pub use discovery::{discover, discover_with_properties};

--- a/src/scpd/mod.rs
+++ b/src/scpd/mod.rs
@@ -45,7 +45,7 @@ impl SCPD {
             .await?;
         let body = std::str::from_utf8(&body)?;
 
-        let document = Document::parse(&body)?;
+        let document = Document::parse(body)?;
         let scpd = utils::find_root(&document, "scpd", "Service Control Point Definition")?;
 
         #[allow(non_snake_case)]

--- a/src/service.rs
+++ b/src/service.rs
@@ -157,11 +157,7 @@ impl Service {
             .children()
             .filter(Node::is_element)
             .filter_map(|node| -> Option<(String, String)> {
-                if let Some(text) = node.text() {
-                    Some((node.tag_name().name().to_string(), text.to_string()))
-                } else {
-                    None
-                }
+                node.text().map(|text| (node.tag_name().name().to_string(), text.to_string()))
             })
             .collect();
 
@@ -290,17 +286,13 @@ macro_rules! yield_try {
 
 #[cfg(feature = "subscribe")]
 fn propertyset_to_map(input: &str) -> Result<HashMap<String, String>, roxmltree::Error> {
-    let doc = Document::parse(&input)?;
+    let doc = Document::parse(input)?;
     let hashmap: HashMap<String, String> = doc
         .root_element() // <e:propertyset />
         .children() // <e:property />
         .filter_map(|child| child.first_element_child()) // actual tag
         .filter_map(|node| {
-            if let Some(text) = node.text() {
-                Some((node.tag_name().name().to_string(), text.to_string()))
-            } else {
-                None
-            }
+            node.text().map(|text| (node.tag_name().name().to_string(), text.to_string()))
         })
         .collect();
 

--- a/src/service.rs
+++ b/src/service.rs
@@ -72,7 +72,7 @@ impl Service {
 
     /// Fetches the [`SCPD`](scpd/struct.SCPD.html) of this service.
     pub async fn scpd(&self, url: &Uri) -> Result<SCPD> {
-        Ok(SCPD::from_url(&self.scpd_url(url), self.service_type().clone()).await?)
+        SCPD::from_url(&self.scpd_url(url), self.service_type().clone()).await
     }
 
     /// Execute some UPnP Action on this service.
@@ -142,7 +142,7 @@ impl Service {
             .await?;
         let doc = std::str::from_utf8(&doc)?;
 
-        let document = Document::parse(&doc)?;
+        let document = Document::parse(doc)?;
         let response = utils::find_root(&document, "Body", "UPnP Response")?
             .first_element_child()
             .ok_or_else(|| {

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -5,7 +5,7 @@ use roxmltree::{Document, Node};
 #[cfg(feature = "subscribe")]
 use std::net::{IpAddr, SocketAddrV4};
 
-pub trait HttpResponseExt: Sized {
+pub(crate) trait HttpResponseExt: Sized {
     fn err_if_not_200(self) -> Result<Self>;
 }
 impl HttpResponseExt for hyper::Response<hyper::Body> {
@@ -17,7 +17,7 @@ impl HttpResponseExt for hyper::Response<hyper::Body> {
         }
     }
 }
-pub trait HyperBodyExt: Sized {
+pub(crate) trait HyperBodyExt: Sized {
     fn text(
         self,
     ) -> std::pin::Pin<


### PR DESCRIPTION
This PR adds a the ability to save custom device properties to the `DeviceSpec` when the device is instantiated. This is helpful when one wants to to keep more information about a device at hand (no new request required) either without enabling the `full_device_spec` or when the desired property isn't included in the full spec.

I use this, for example, to load the `roomName` for Sonos devices at the time of discovery.

The changes here don't impact any of the existing public API -- the new features are accessed by new public functions. The action and signature of existing public functions is unchanged.