### PR TITLE
Switch to if-addrs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ license = "MIT/Apache-2.0"
 edition = "2018"
 
 [features]
-default = ["subscribe", "genawaiter", "get_if_addrs"]
+default = ["subscribe", "genawaiter", "if-addrs"]
 
 full_device_spec = []
 subscribe = ["tokio"]
@@ -21,7 +21,7 @@ tokio = { version = "1.0", features = ["net", "io-util"], optional = true }
 futures-core = "0.3"
 futures-util = { version = "0.3", default-features = false }
 genawaiter = { version = "0.99", default-features = false, features = ["futures03"], optional = true }
-get_if_addrs = { version = "0.5", optional = true }
+if-addrs = { version = "0.13", optional = true }
 http = "0.2"
 ssdp-client = "2.0"
 roxmltree = "0.18"

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,6 +1,6 @@
 use crate::{Error, Result};
 #[cfg(feature = "subscribe")]
-use get_if_addrs::{get_if_addrs, Interface};
+use if_addrs::{get_if_addrs, Interface};
 use roxmltree::{Document, Node};
 #[cfg(feature = "subscribe")]
 use std::net::{IpAddr, SocketAddrV4};


### PR DESCRIPTION
[get_if_addrs](https://github.com/maidsafe-archive/get_if_addrs) is no longer maintained and lacks support for operating systems such as illumos. This PR switches rupnp's use of get_if_addrs for the maintained and updated [if-addrs](https://github.com/messense/if-addrs)


```
❯ cargo t
   Compiling rupnp v2.0.0 (/home/link/src/rupnp)
    Finished `test` profile [unoptimized + debuginfo] target(s) in 2.65s
     Running unittests src/lib.rs (target/debug/deps/rupnp-0832ba707c38ee95)

running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s

   Doc-tests rupnp

running 4 tests
test src/service.rs - service::Service::subscribe (line 208) - compile ... ok
test src/service.rs - service::Service::action (line 84) - compile ... ok
test src/discovery.rs - discovery::discover (line 9) - compile ... ok
test src/lib.rs - (line 20) - compile ... ok

test result: ok. 4 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.09s
```