### PR TITLE
Avoid implicit features

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,10 +12,10 @@ edition = "2018"
 rust-version = "1.75"
 
 [features]
-default = ["subscribe", "genawaiter", "if-addrs"]
+default = ["subscribe"]
 
 full_device_spec = []
-subscribe = ["tokio"]
+subscribe = ["dep:tokio", "dep:genawaiter", "dep:if-addrs"]
 
 [dependencies]
 tokio = { version = "1.0", features = ["net", "io-util"], optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,8 +14,8 @@ rust-version = "1.75"
 [features]
 default = ["subscribe"]
 
-full_device_spec = []
-subscribe = ["dep:tokio", "dep:genawaiter", "dep:if-addrs"]
+full_device_spec = [] # store and expose the full DeviceSpec properties
+subscribe = ["dep:tokio", "dep:genawaiter", "dep:if-addrs"] # event notifications & state variable changes
 
 [dependencies]
 tokio = { version = "1.0", features = ["net", "io-util"], optional = true }


### PR DESCRIPTION
This PR changes the feature list to avoid [rust implicit features](https://doc.rust-lang.org/cargo/reference/features.html#optional-dependencies) and properly defines all required dependencies for the `subscribe` feature.
Also try adding some documentation for the features.